### PR TITLE
Return value on SignOut

### DIFF
--- a/flutter_aws_amplify_cognito/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_aws_amplify_cognito/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/flutter_aws_amplify_cognito/android/src/main/kotlin/in/agnostech/flutter_aws_amplify_cognito/CognitoMethodChannelHandler.kt
+++ b/flutter_aws_amplify_cognito/android/src/main/kotlin/in/agnostech/flutter_aws_amplify_cognito/CognitoMethodChannelHandler.kt
@@ -10,7 +10,7 @@ class CognitoMethodChannelHandler(private val context: Context) : MethodChannel.
             "isSignedIn" -> result.success(FlutterAwsAmplifyCognito.isSignedIn())
             "currentUserState" -> FlutterAwsAmplifyCognito.currentUserState(result)
             "initialize" -> FlutterAwsAmplifyCognito.initialize(context, result)
-            "signOut" -> FlutterAwsAmplifyCognito.signOut()
+            "signOut" -> FlutterAwsAmplifyCognito.signOut(result)
             "signOutGlobally" -> FlutterAwsAmplifyCognito.signOutGlobally(result)
             "getUserAttributes" -> FlutterAwsAmplifyCognito.getUserAttributes(result)
             "getUsername" -> FlutterAwsAmplifyCognito.getUsername(result)

--- a/flutter_aws_amplify_cognito/android/src/main/kotlin/in/agnostech/flutter_aws_amplify_cognito/FlutterAwsAmplifyCognito.kt
+++ b/flutter_aws_amplify_cognito/android/src/main/kotlin/in/agnostech/flutter_aws_amplify_cognito/FlutterAwsAmplifyCognito.kt
@@ -45,7 +45,22 @@ class FlutterAwsAmplifyCognito {
                     }
                 })
 
-        fun signOut() = AWSMobileClient.getInstance().signOut()
+        fun signOut(result: MethodChannel.Result) = AWSMobileClient.getInstance().signOut(
+                SignOutOptions.builder().signOutGlobally(false).build(),
+                object : Callback<Void> {
+                    override fun onResult(result: Void?) {
+                        Handler(Looper.getMainLooper()).post {
+                            result.success(true)
+                        }
+                    }
+
+                    override fun onError(e: Exception?) {
+                        Handler(Looper.getMainLooper()).post {
+                            result.error("Error", "Error signing in", e.localizedMessage)
+                        }
+                    }
+                }
+        )
         fun signOutGlobally(result: MethodChannel.Result) = AWSMobileClient.getInstance().signOut(
                 SignOutOptions.builder().signOutGlobally(true).build(),
                 object : Callback<Void> {

--- a/flutter_aws_amplify_cognito/android/src/main/kotlin/in/agnostech/flutter_aws_amplify_cognito/FlutterAwsAmplifyCognito.kt
+++ b/flutter_aws_amplify_cognito/android/src/main/kotlin/in/agnostech/flutter_aws_amplify_cognito/FlutterAwsAmplifyCognito.kt
@@ -48,7 +48,7 @@ class FlutterAwsAmplifyCognito {
         fun signOut(result: MethodChannel.Result) = AWSMobileClient.getInstance().signOut(
                 SignOutOptions.builder().signOutGlobally(false).build(),
                 object : Callback<Void> {
-                    override fun onResult(result: Void?) {
+                    override fun onResult(signOutResult: Void?) {
                         Handler(Looper.getMainLooper()).post {
                             result.success(true)
                         }

--- a/flutter_aws_amplify_cognito/android/src/main/kotlin/in/agnostech/flutter_aws_amplify_cognito/FlutterAwsAmplifyCognito.kt
+++ b/flutter_aws_amplify_cognito/android/src/main/kotlin/in/agnostech/flutter_aws_amplify_cognito/FlutterAwsAmplifyCognito.kt
@@ -54,7 +54,7 @@ class FlutterAwsAmplifyCognito {
                         }
                     }
 
-                    override fun onError(e: Exception?) {
+                    override fun onError(e: Exception) {
                         Handler(Looper.getMainLooper()).post {
                             result.error("Error", "Error signing in", e.localizedMessage)
                         }

--- a/flutter_aws_amplify_cognito/ios/Classes/CognitoMethodChannelHandler.swift
+++ b/flutter_aws_amplify_cognito/ios/Classes/CognitoMethodChannelHandler.swift
@@ -24,7 +24,7 @@ func handleMethodCall(call: FlutterMethodCall, result: @escaping FlutterResult) 
         SwiftFlutterAwsAmplifyCognito.initialize(result: result)
         
     case "signOut":
-        SwiftFlutterAwsAmplifyCognito.signOut()
+        SwiftFlutterAwsAmplifyCognito.signOut(result: result)
         
     case "signOutGlobally":
         SwiftFlutterAwsAmplifyCognito.signOutGlobally(result: result)

--- a/flutter_aws_amplify_cognito/ios/Classes/SwiftFlutterAwsAmplifyCognito.swift
+++ b/flutter_aws_amplify_cognito/ios/Classes/SwiftFlutterAwsAmplifyCognito.swift
@@ -78,8 +78,17 @@ class SwiftFlutterAwsAmplifyCognito {
         }
     }
     
-    static func signOut() {
-        AWSMobileClient.default().signOut()
+    static func signOut(result: @escaping FlutterResult) {
+        AWSMobileClient.default().signOut() { (error) in
+            if (error != nil) {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "Error", message: "Error signing out", details: error?.localizedDescription))
+                }
+            }
+            DispatchQueue.main.async {
+                result(true)
+            }
+        }
     }
     
     static func signOutGlobally(result: @escaping FlutterResult) {


### PR DESCRIPTION
Calling SignOut now returns either `true` or an Error once the function has finished executing.  

### Attached Issue 
- https://github.com/agnostech/flutter_amplify/issues/19